### PR TITLE
fix: don't force duration field type

### DIFF
--- a/src/resources/IssueTimeTracking.ts
+++ b/src/resources/IssueTimeTracking.ts
@@ -76,7 +76,7 @@ export class IssueTimeTrackingApi extends ResourceApi {
    */
   async createIssueWorkItem<TSchema extends IssueWorkItemSchema>(
     issueId: string,
-    body: { duration: number } & DeepPartial<IssueWorkItem>,
+    body: DeepPartial<IssueWorkItem>,
     params?: FieldsParam<TSchema> & MuteUpdateNotificationsParam,
   ): Promise<IssueWorkItemEntity<TSchema>> {
     return this.youtrack.fetch<IssueWorkItemEntity<TSchema>>(


### PR DESCRIPTION
Forcing `{duration: number}` for `createIssueWorkItem` results in type mismatch error during creating, so I used `fields` instead to overcome this issue