### PR TITLE
fix: omit redundant field for issue creation

### DIFF
--- a/src/resources/Issues.ts
+++ b/src/resources/Issues.ts
@@ -69,7 +69,7 @@ export class IssuesApi extends ResourceApi {
    * @returns The created issue.
    */
   async createIssue<TSchema extends IssueSchema>(
-    body: { summary: string; project: string } & DeepPartial<Issue>,
+    body: { summary: string; project: string } & DeepPartial<Omit<Issue, "project">>,
     params?: FieldsParam<TSchema> & MuteUpdateNotificationsParam & { draftId?: string },
   ): Promise<IssueEntity<TSchema>> {
     return this.youtrack.fetch<IssueEntity<TSchema>>(


### PR DESCRIPTION
As `project` already passed to the body we should omit it from the `Issue`
Closes https://github.com/udamir/youtrack-client/issues/4