### PR TITLE
fixup PR #6

### DIFF
--- a/src/resources/Issues.ts
+++ b/src/resources/Issues.ts
@@ -69,7 +69,7 @@ export class IssuesApi extends ResourceApi {
    * @returns The created issue.
    */
   async createIssue<TSchema extends IssueSchema>(
-    body: { summary: string; project: string } & DeepPartial<Omit<Issue, "project">>,
+    body: { summary: string; project: {id: string } } & DeepPartial<Omit<Issue, "project">>,
     params?: FieldsParam<TSchema> & MuteUpdateNotificationsParam & { draftId?: string },
   ): Promise<IssueEntity<TSchema>> {
     return this.youtrack.fetch<IssueEntity<TSchema>>(


### PR DESCRIPTION
<img width="852" alt="image" src="https://github.com/user-attachments/assets/0a813ea5-332e-4ab1-a719-078b9e14461c" />

One cannot specify project as a string, so this fix  addresses  this for `createIssue` method
